### PR TITLE
Fix archive defaults and append done items

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,10 @@ Available configuration options include:
 |--------|-------------|---------|
 | `default_priority` | Default priority for new tasks | None |
 | `date_format` | Format for displaying dates | %Y-%m-%d |
-| `auto_archive` | Automatically archive completed tasks | false |
+| `archive_completed` | Automatically archive completed tasks | false |
 | `editor` | Editor to use when editing tasks | $EDITOR or vi |
-| `git_auto_commit` | Automatically commit changes | false |
-| `git_auto_push` | Automatically push after commit | false |
+| `auto_commit` | Automatically commit changes | false |
+| `auto_sync` | Automatically push after commit | false |
 
 ## Git Integration
 
@@ -255,8 +255,8 @@ ptodo edit 5
 ptodo tasks edit 5
 
 # Configure Git auto-sync
-ptodo config set git_auto_commit true
-ptodo config set git_auto_push true
+ptodo config set auto_commit true
+ptodo config set auto_sync true
 ```
 
 ## Contributing

--- a/ptodo/commands/task_commands.py
+++ b/ptodo/commands/task_commands.py
@@ -13,8 +13,8 @@ from ..core import (
     sort_tasks,
     write_tasks,
 )
-from ..git_service import GitService
 from ..core.serda import Task, create_task, parse_date, parse_task
+from ..git_service import GitService
 
 # ANSI color codes for formatting
 RESET = "\033[0m"
@@ -82,11 +82,11 @@ def cmd_list(args: argparse.Namespace) -> int:
             task_dict = task.to_dict()
             task_dict["task_id"] = original_idx + 1
             tasks_json.append(task_dict)
-        
+
         output = {
             "tasks": tasks_json,
             "total_tasks": len(all_tasks),
-            "shown_tasks": len(indexed_tasks)
+            "shown_tasks": len(indexed_tasks),
         }
         print(json.dumps(output, indent=2))
         return 0
@@ -241,7 +241,10 @@ def cmd_done(args: argparse.Namespace) -> int:
                 print(f"Archiving: {len(completed_tasks)} task(s)")
             done_file = get_done_file_path()
             incomplete_tasks = [t for t in tasks if not t.completed]
-            write_tasks(completed_tasks, done_file, git_service)
+            # Append to existing done.txt instead of overwriting
+            existing_done = read_tasks(done_file, git_service)
+            existing_done.extend(completed_tasks)
+            write_tasks(existing_done, done_file, git_service)
             write_tasks(incomplete_tasks, todo_file, git_service)
         else:
             write_tasks(tasks, todo_file, git_service)

--- a/ptodo/config.py
+++ b/ptodo/config.py
@@ -11,7 +11,7 @@ T = TypeVar("T")
 DEFAULT_CONFIG: Dict[str, Union[str, bool, Optional[int]]] = {
     "todo_file": "todo.txt",
     "done_file": "done.txt",
-    "archive_completed": True,
+    "archive_completed": False,
     "default_priority": "C",
     "show_colors": True,
     "date_format": "%Y-%m-%d",


### PR DESCRIPTION
## Summary
- change `archive_completed` default to `False`
- keep previous tasks when auto-archiving
- update README and examples for new config keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509d9178fc8328835727942220f274